### PR TITLE
fix(http_client): add configurable recv_timeout to HTTPoison requests

### DIFF
--- a/lib/newtail_elixir/http_client.ex
+++ b/lib/newtail_elixir/http_client.ex
@@ -6,8 +6,10 @@ defmodule NewtailElixir.HttpClient do
   def post(body, type, opts) do
     url = build_url(type, opts)
     headers = headers(opts)
+    recv_timeout = Keyword.get(opts, :recv_timeout, 5_000)
 
-    http_client().post(url, body, headers) |> handle_response(url)
+    http_client().post(url, body, headers, recv_timeout: recv_timeout)
+    |> handle_response(url)
   end
 
   defp build_url(:products, _opts), do: base_url() <> "/product/bulk/products"


### PR DESCRIPTION
## Contexto

Chamadas HTTP ao Newtail usavam o `recv_timeout` padrão do HTTPoison (5000ms). No Axolotl, essas chamadas rodam dentro de `Task.async` com timeout de 100ms. Quando a task era encerrada via `brutal_kill`, a conexão TCP ficava viva no pool do Hackney por até 5s — contribuindo para acúmulo de memória e OOMKill sob carga.

## O que muda

`HttpClient.post/3` agora lê `recv_timeout` dos `opts` do chamador, com fallback para 5000ms (comportamento anterior preservado).

```elixir
recv_timeout = Keyword.get(opts, :recv_timeout, 5_000)
http_client().post(url, body, headers, recv_timeout: recv_timeout)
```

## Plano de testes

- [ ] Testes existentes passando
- [ ] Chamadas sem `recv_timeout` nos opts mantêm comportamento anterior (5000ms)
- [ ] Axolotl passando `recv_timeout: 90` via `newtail_opts/0` após merge desta lib

**Nota:** deve ser mergeado antes do PR do Axolotl que depende desta mudança.