### PR TITLE
fix(http_client): dispatch to mock without options when client is not HTTPoison

### DIFF
--- a/lib/newtail_elixir/http_client.ex
+++ b/lib/newtail_elixir/http_client.ex
@@ -8,7 +8,10 @@ defmodule NewtailElixir.HttpClient do
     headers = headers(opts)
     recv_timeout = Keyword.get(opts, :recv_timeout, 5_000)
 
-    http_client().post(url, body, headers, recv_timeout: recv_timeout)
+    case http_client() do
+      HTTPoison -> HTTPoison.post(url, body, headers, recv_timeout: recv_timeout)
+      client -> client.post(url, body, headers)
+    end
     |> handle_response(url)
   end
 


### PR DESCRIPTION
## Contexto

Continuação do PR #6. Após adicionar `recv_timeout`, o `HttpClient.post/3` passou a chamar sempre `http_client().post/4` — quebrando mocks que só implementam `post/3`.

## O que muda

Usa `case http_client()` para despachar: se for `HTTPoison`, chama com `recv_timeout`; caso contrário, chama sem opts (compatível com mocks).

```elixir
case http_client() do
  HTTPoison -> HTTPoison.post(url, body, headers, recv_timeout: recv_timeout)
  client -> client.post(url, body, headers)
end
```

## Plano de testes

- [ ] Testes existentes passando (mocks não recebem mais `post/4`)
- [ ] Comportamento em produção preservado (`HTTPoison` ainda recebe `recv_timeout`)